### PR TITLE
feat: timeout as parameter

### DIFF
--- a/lib/transbank/common/options.ts
+++ b/lib/transbank/common/options.ts
@@ -11,6 +11,8 @@ class Options {
   /** Environment correspond to the environment to use, it can be Integration or
    * Production, each has a unique URL. */
   environment: string;
+  /** Timeout for requests in milliseconds */
+  timeout: number;
 
   /**
    * Create an instance of Options
@@ -18,11 +20,13 @@ class Options {
    * @param apiKey the secret used to authenticate against the API, it must be kept safe at all times.
    * @param environment Environment correspond to the environment to use, it can be Integration or
    * Production, each has a unique URL.
+   * @param timeout Timeout for requests in milliseconds
    */
-  constructor(commerceCode: string, apiKey: string, environment: string) {
+  constructor(commerceCode: string, apiKey: string, environment: string, timeout?: number) {
     this.commerceCode = commerceCode;
     this.apiKey = apiKey;
     this.environment = environment;
+    this.timeout = timeout ?? 60000;
   }
 }
 

--- a/lib/transbank/common/request_service.ts
+++ b/lib/transbank/common/request_service.ts
@@ -36,7 +36,7 @@ const RequestService = {
       method: request.method,
       url: options.environment + request.endpoint,
       headers: requestHeaders,
-      timeout: 10000,
+      timeout: options.timeout,
       data: request.toJson(),
     })
       .then((response) => {
@@ -67,12 +67,14 @@ const RequestService = {
         return response.data;
       })
       .catch((error) => {
-        console.log(error)
         let response = error.response;
-        let msg = (response?.data?.code || response?.data?.description) ? (`${response.data.code} - ${response.data.description}`) : 'Unexpected error';
+        let msg =
+          response?.data?.code || response?.data?.description
+            ? `${response.data.code} - ${response.data.description}`
+            : 'Unexpected error';
         throw new TransbankError(error, msg);
       });
-  }
+  },
 };
 
 export default RequestService;


### PR DESCRIPTION
This PR adds a `timeout` parameter to the `perform` method on `RequestService`, so users can now configure how many milliseconds until receiving a timeout from the Request.