### PR TITLE
refactor: make timeout optional

### DIFF
--- a/lib/transbank/common/options.ts
+++ b/lib/transbank/common/options.ts
@@ -12,7 +12,7 @@ class Options {
    * Production, each has a unique URL. */
   environment: string;
   /** Timeout for requests in milliseconds */
-  timeout: number;
+  timeout?: number;
 
   /**
    * Create an instance of Options


### PR DESCRIPTION
This pull request modifies the `Options` class by making the `timeout` field optional.

Previously, the `timeout` field was already optional in the `Options` constructor. However, if a user tries to pass the `Options` parameter as an object and not an instance of the `Options` class, TypeScript will throw an error due to the missing `timeout` field.