### PR TITLE
TBK-375 chore: add matrix node versions v22-v24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["22.x", "24.x"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -22,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: "24.x"
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: pnpm install --ignore-scripts
       - name: Build
@@ -30,6 +33,7 @@ jobs:
       - name: Run tests with coverage
         run: pnpm run test:coverage
       - name: SonarQube Scan
+        if: matrix.node-version == '24.x'
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: ["22.x", "24.x"]
     steps:


### PR DESCRIPTION
## Description
The SDK officially supports Node 22 through Node 24, but CI (build.yml) only ran tests against a single fixed version (24.x). This change adds a matrix to validate the build and tests across both supported versions.

## Changes
- Added strategy.matrix to the build job in [build.yml](vscode-webview://0s0he8sk7k5ehvp9ju5ti36v670i2jaekjojp3b7oqb41f81tq5h/.github/workflows/build.yml) to run on Node 22.x and 24.x.
- The Use Node.js step now uses ${{ matrix.node-version }} instead of the fixed version.
The SonarQube Scan step now only runs on the Node 24.x job (if: matrix.node-version == '24.x'), to prevent both matrix jobs from submitting analysis for the same commit in parallel and overwriting each other non-deterministically.

## Test
<img width="1341" height="521" alt="image" src="https://github.com/user-attachments/assets/fe5c4a77-0112-4ba8-9eb5-1071a2518c6e" />
