### PR TITLE
TBK-380 chore: add new sonar job with build dependence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,27 @@ jobs:
         run: pnpm run build
       - name: Run tests with coverage
         run: pnpm run test:coverage
-      - name: SonarQube Scan
+      - name: Upload coverage report
         if: matrix.node-version == '24.x'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: coverage-report
+          path: coverage/
+
+  sonar:
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: coverage-report
+          path: coverage/
+      - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm run test:coverage
       - name: Upload coverage report
         if: matrix.node-version == '24.x'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-report
           path: coverage/
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download coverage report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: coverage-report
           path: coverage/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
         node-version: ["22.x", "24.x"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
       - name: Use pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
         with:


### PR DESCRIPTION
## Description
The SonarQube analysis currently runs as a conditional step (if: matrix.node-version == '24.x') inside the same build job that runs the Node.js 22.x/24.x matrix. This couples static analysis to the matrix job and exposes it to fail-fast behavior: if one Node version's job fails or gets cancelled before reaching the SonarQube step, the analysis can be silently skipped for that commit.

This PR splits SonarQube into an independent sonar job that depends on the build job via needs, so the analysis runs explicitly instead of relying on a condition inside the matrix.

## Changes
- Extracted the SonarQube Scan step out of the build job into a new sonar job with needs: build.
- The build job now uploads the coverage report (coverage/) as an artifact only from the Node 24.x run, since that job no longer shares a filesystem with sonar.
- The sonar job does its own checkout (with fetch-depth: 0, required by SonarQube for new-code analysis and git blame) and downloads the coverage artifact before running the scan.

## Test
<img width="2518" height="705" alt="image" src="https://github.com/user-attachments/assets/a2e6624e-05a4-4301-9caa-07e6f43d02cf" />
